### PR TITLE
fix: added transmitter for ctrl + s

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { Excalidraw } from "@excalidraw/excalidraw";
 import type { ExcalidrawElement } from "@excalidraw/excalidraw/element/types";
+import { useEffect, useRef } from "react";
 
 type AppProps = {
   initialElements?: ExcalidrawElement[];
@@ -7,6 +8,25 @@ type AppProps = {
 };
 
 function App({ initialElements = [], isReadonly = false }: AppProps) {
+  const elementsRef = useRef<readonly ExcalidrawElement[]>(initialElements);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+        event.preventDefault();
+        window.parent.postMessage({
+          type: "not3/draw/save",
+          payload: elementsRef.current,
+        }, "*");
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
   return (
     <>
       <div style={{ height: "100%", width: "100%" }}>
@@ -31,6 +51,7 @@ function App({ initialElements = [], isReadonly = false }: AppProps) {
           viewModeEnabled={isReadonly}
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           onChange={(excalidrawElements, _appState, _files) => {
+            elementsRef.current = excalidrawElements;
             window.parent.postMessage({
               type: "not3/draw/change",
               payload: excalidrawElements,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ function App({ initialElements = [], isReadonly = false }: AppProps) {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.ctrlKey || event.metaKey) && event.key === "s") {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "s") {
         event.preventDefault();
         window.parent.postMessage({
           type: "not3/draw/save",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,10 @@ function App({ initialElements = [], isReadonly = false }: AppProps) {
   const elementsRef = useRef<readonly ExcalidrawElement[]>(initialElements);
 
   useEffect(() => {
+    elementsRef.current = initialElements;
+  }, [initialElements]);
+
+  useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "s") {
         event.preventDefault();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,4 +8,7 @@ export default defineConfig({
   define: {
     "process.env.IS_PREACT": JSON.stringify("true"),
   },
+  server: {
+    allowedHosts: true,
+  },
 })


### PR DESCRIPTION
## Description
Provides a not3/draw/save event to tell the parent page to save the file.

## Related Issue
Closes https://github.com/not-three/main/issues/19

## Screenshots (if applicable)
n/a

## Checklist

- [x] I have tested my changes locally
- [x] I have updated the documentation if needed
- [x] This PR follows the project's coding style

## Additional Notes
n/a
